### PR TITLE
Set HAVE_STRUCT_TIMESPEC on pthread.h

### DIFF
--- a/pthread-win32/pthread.h
+++ b/pthread-win32/pthread.h
@@ -30,6 +30,13 @@
  *      59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
  */
 
+/*
+ * Fix build for VS2017 (possibly VS2015 as well?)
+ * See https://stackoverflow.com/questions/33557506/timespec-redefinition-error
+ */
+#define HAVE_STRUCT_TIMESPEC
+
+
 #if !defined( PTHREAD_H )
 #define PTHREAD_H
 


### PR DESCRIPTION
This is required to build on VS2017, see https://stackoverflow.com/questions/33557506/timespec-redefinition-error